### PR TITLE
Changing deprecated .H and np.complex

### DIFF
--- a/Assignment_4/Assigment4-PV.ipynb
+++ b/Assignment_4/Assigment4-PV.ipynb
@@ -135,7 +135,7 @@
     "    \n",
     "    # Solve the linear system\n",
     "    A = sp.coo_matrix((data, (ii, jj)), shape=(index, F.shape[0])).asformat(\"csr\")\n",
-    "    u = sp.linalg.spsolve(A.H @ A, A.H @ b)\n",
+    "    u = sp.linalg.spsolve(A.conj().T @ A, A.conj().T @ b)\n",
     "    \n",
     "    R = np.zeros_like(T1)\n",
     "    \n",
@@ -206,7 +206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "gp",
    "language": "python",
    "name": "python3"
   },
@@ -220,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/Assignment_4/Assigment4.ipynb
+++ b/Assignment_4/Assigment4.ipynb
@@ -99,7 +99,7 @@
     "    # Convert the constraints into the complex polynomial coefficients and add them as soft constraints\n",
     "    \n",
     "    # Rhs of the system\n",
-    "    b = np.zeros(index + soft_id.shape[0], dtype=np.complex)\n",
+    "    b = np.zeros(index + soft_id.shape[0], dtype=np.complex128)\n",
     "    \n",
     "    for ci in range(soft_id.shape[0]):\n",
     "        f = soft_id[ci]\n",
@@ -118,7 +118,7 @@
     "    \n",
     "    # Solve the linear system\n",
     "    A = sp.coo_matrix((data, (ii, jj)), shape=(index, F.shape[0])).asformat(\"csr\")\n",
-    "    u = sp.linalg.spsolve(A.H @ A, A.H @ b)\n",
+    "    u = sp.linalg.spsolve(A.conj().T @ A, A.conj().T @ b)\n",
     "    \n",
     "    R = T1 * u.real[:,None] + T2 * u.imag[:,None]\n",
     "\n",
@@ -157,11 +157,18 @@
     "R = align_field(v, f, tt, cf, c, 1e6)\n",
     "plot_mesh_field(v, f, R, cf)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "gp",
    "language": "python",
    "name": "python3"
   },
@@ -175,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed occurrences of A.H to A.conj().T as .H was deprecated in Scipy version 1.11.0 and will be removed in v1.14.0 (https://docs.scipy.org/doc/scipy-1.13.0/reference/generated/scipy.sparse.csr_matrix.H.html). Also, changed np.complex to np.complex128 since np.complex was deprecated in NumPy version 1.20 and removed in version 1.24